### PR TITLE
chore(docker): update docker-compose configuration for backend service

### DIFF
--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -1,24 +1,24 @@
-version: '3.8'
-
 services:
-  # Backend service only (MongoDB Atlas used externally)
   backend:
     build:
-      context: ./backend
+      context: .                # FIXED: build from current directory
       dockerfile: Dockerfile
     container_name: aivoice-backend
     restart: unless-stopped
     environment:
-      - NODE_ENV=production
-      - PORT=3001
-      - MONGODB_URI=${MONGODB_URI}
-      - FRONTEND_URL=${FRONTEND_URL}
-      - OPENAI_API_KEY=${OPENAI_API_KEY}
-      - JWT_SECRET=${JWT_SECRET}
-      - CORS_ORIGIN=${CORS_ORIGIN}
+      NODE_ENV: production
+      PORT: 3001
+      MONGODB_URI: ${MONGODB_URI}
+      FRONTEND_URL: ${FRONTEND_URL}
+      OPENAI_API_KEY: ${OPENAI_API_KEY}
+      JWT_SECRET: ${JWT_SECRET}
+      CORS_ORIGIN: ${CORS_ORIGIN}
+      TZ: ${TZ}
     ports:
       - "3001:3001"
-      - "80:3001"  # Also expose on port 80 for easier access
+      # ⚠️ If you really need port 80 → 3001, keep the line below
+      # but note: binding 80 often requires sudo/root
+      # - "80:3001"
     volumes:
       - backend_data:/app/data
       - ./logs:/app/logs
@@ -34,10 +34,10 @@ services:
       resources:
         limits:
           memory: 1G
-          cpus: '1.0'
+          cpus: "1.0"
         reservations:
           memory: 512M
-          cpus: '0.5'
+          cpus: "0.5"
     logging:
       driver: "json-file"
       options:


### PR DESCRIPTION
- Adjust build context to current directory for improved clarity
- Refactor environment variables to use key-value format
- Add timezone variable for better environment configuration
- Comment on port 80 binding to clarify potential permission issues

## Summary by Sourcery

Update the backend service’s docker-compose configuration

Enhancements:
- Change build context to the project root directory for clarity
- Refactor environment variables to key-value pairs and add a TZ variable
- Comment out the port 80 binding with a note about elevated permissions
- Normalize CPU limit and reservation values to use double-quoted strings